### PR TITLE
Fix zod number validation

### DIFF
--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -28,8 +28,8 @@ const formSchema = z.object({
     required_error: "日付を入力してください。",
   }),
   raceName: z.string().optional(),
-  betAmount: z.coerce.number().min(1, { message: "1円以上の掛け金を入力してください。" }).step(100),
-  payoutAmount: z.coerce.number().min(0, { message: "0円以上の払戻金を入力してください。" }).step(10),
+  betAmount: z.coerce.number().min(1, { message: "1円以上の掛け金を入力してください。" }).multipleOf(100),
+  payoutAmount: z.coerce.number().min(0, { message: "0円以上の払戻金を入力してください。" }).multipleOf(10),
 });
 
 type EntryFormValues = z.infer<typeof formSchema>;


### PR DESCRIPTION
## Summary
- use `multipleOf` instead of deprecated `step` for zod numbers in `EntryForm`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module)*


------
https://chatgpt.com/codex/tasks/task_e_68497f3d2348832bab6d97f54885e828