### PR TITLE
Update comment for EntryForm prop

### DIFF
--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -41,7 +41,8 @@ interface EntryFormProps {
   initialData?: BetEntry;
   isEditMode?: boolean;
   onClose?: () => void;
-  isInDialog?: boolean; // New prop
+  // true when the form is rendered inside a dialog
+  isInDialog?: boolean;
 }
 
 export function EntryForm({ 


### PR DESCRIPTION
## Summary
- rephrase comment for `isInDialog` in `EntryForm` so it no longer says "New prop"

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next' et al)*

------
https://chatgpt.com/codex/tasks/task_e_68497f48f6c0832b9da041367221f69b