### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 import Link from 'next/link';
-import { Ticket, Menu, PlusCircle, Settings } from 'lucide-react'; // Settings を追加
+import { Ticket, Menu, PlusCircle, Settings, Moon, Sun } from 'lucide-react'; // Settings を追加
 import { useIsMobile } from '@/hooks/use-mobile';
 import type { LucideIcon } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
@@ -15,6 +15,8 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { useDashboardDialog } from '@/contexts/DashboardDialogContext'; // ダイアログ用コンテキストを追加
+import useTheme from '@/hooks/useTheme';
+import ThemeToggleButton from './ThemeToggleButton';
 
 interface NavItem {
   href: string;
@@ -33,6 +35,9 @@ export function AppHeader({ appName, navItems, onOpenAddEntryDialog }: AppHeader
   const pathname = usePathname();
   const router = useRouter();
   const { setIsSettingsDialogOpen } = useDashboardDialog(); // 追加したコンテキスト
+  const [theme, setTheme] = useTheme();
+  const isDark = theme === 'dark';
+  const toggleTheme = () => setTheme(isDark ? 'light' : 'dark');
 
   const isActive = (href: string) => {
     if (href === '/dashboard') {
@@ -105,6 +110,7 @@ export function AppHeader({ appName, navItems, onOpenAddEntryDialog }: AppHeader
                     <Settings className="h-5 w-5" />
                 </Button>
               )}
+              <ThemeToggleButton />
             </>
           )}
 
@@ -142,6 +148,14 @@ export function AppHeader({ appName, navItems, onOpenAddEntryDialog }: AppHeader
                         <span>設定</span>
                     </DropdownMenuItem>
                 )}
+                <DropdownMenuItem onClick={toggleTheme} className="cursor-pointer">
+                  {isDark ? (
+                    <Sun className="mr-2 h-4 w-4" />
+                  ) : (
+                    <Moon className="mr-2 h-4 w-4" />
+                  )}
+                  <span>テーマ切替</span>
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (

--- a/src/components/ThemeToggleButton.tsx
+++ b/src/components/ThemeToggleButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Moon, Sun } from "lucide-react";
+import useTheme from "@/hooks/useTheme";
+
+export default function ThemeToggleButton() {
+  const [theme, setTheme] = useTheme();
+  const isDark = theme === "dark";
+
+  const toggle = () => setTheme(isDark ? "light" : "dark");
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label="テーマ切替"
+    >
+      {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  );
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import useLocalStorage from "./useLocalStorage";
+
+export type Theme = "light" | "dark";
+
+export default function useTheme(): [Theme, (value: Theme) => void] {
+  const [theme, setTheme] = useLocalStorage<Theme>("theme", "light");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [theme]);
+
+  return [theme, setTheme];
+}


### PR DESCRIPTION
## Summary
- add `useTheme` hook to manage theme
- add `ThemeToggleButton` component
- integrate theme toggle in `AppHeader`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684b6f7f407c832b9cdf237a0d0db6c2