### PR TITLE
Add hidden title to auth dialog

### DIFF
--- a/src/components/AuthDialog.tsx
+++ b/src/components/AuthDialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useSupabase } from "@/contexts/SupabaseProvider";
 
 export default function AuthDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
@@ -12,7 +12,16 @@ export default function AuthDialog({ open, onOpenChange }: { open: boolean; onOp
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
-        <Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} providers={["google", "apple"]} view="magic_link" redirectTo={redirectTo} />
+        <DialogHeader>
+          <DialogTitle className="sr-only">ログイン</DialogTitle>
+        </DialogHeader>
+        <Auth
+          supabaseClient={supabase}
+          appearance={{ theme: ThemeSupa }}
+          providers={["google", "apple"]}
+          view="magic_link"
+          redirectTo={redirectTo}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## 概要
- AuthDialog コンポーネントに非表示の `DialogTitle` を追加し、アクセシビリティエラーを解消しました。

## テスト結果
- `yarn lint` と `yarn typecheck` は依存関係未インストールのため実行できませんでした。


------
https://chatgpt.com/codex/tasks/task_e_684e96fc84bc832bbe95a10d166d7c16