### PR TITLE
Refactor authentication with supabase

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,14 +1,12 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { type NextRequest } from 'next/server'
+import { updateSession } from '@/utils/supabase/middleware'
 
-export function middleware(req: NextRequest) {
-  const token = req.cookies.get('sb-access-token');
-  if (!token) {
-    return NextResponse.redirect(new URL('/login', req.url));
-  }
-  return NextResponse.next();
+export async function middleware(request: NextRequest) {
+  return await updateSession(request)
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*'],
-};
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+}

--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -1,0 +1,22 @@
+import { type EmailOtpType } from '@supabase/supabase-js'
+import { type NextRequest } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import { redirect } from 'next/navigation'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const token_hash = searchParams.get('token_hash')
+  const type = searchParams.get('type') as EmailOtpType | null
+  const next = searchParams.get('next') ?? '/'
+  if (token_hash && type) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    })
+    if (!error) {
+      redirect(next)
+    }
+  }
+  redirect('/error')
+}

--- a/src/app/error/page.tsx
+++ b/src/app/error/page.tsx
@@ -1,0 +1,3 @@
+export default function ErrorPage() {
+  return <p>エラーが発生しました。</p>
+}

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,26 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+import { redirect } from 'next/navigation'
+
+export async function login(formData: FormData) {
+  const supabase = createClient()
+  const email = formData.get('email') as string
+  const password = formData.get('password') as string
+  const { error } = await supabase.auth.signInWithPassword({ email, password })
+  if (error) {
+    redirect('/error')
+  }
+  redirect('/dashboard')
+}
+
+export async function signup(formData: FormData) {
+  const supabase = createClient()
+  const email = formData.get('email') as string
+  const password = formData.get('password') as string
+  const { error } = await supabase.auth.signUp({ email, password })
+  if (error) {
+    redirect('/error')
+  }
+  redirect('/dashboard')
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,20 +1,14 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import AuthDialog from "@/components/AuthDialog";
-import { useSupabase } from "@/contexts/SupabaseProvider";
+import { login, signup } from './actions'
 
 export default function LoginPage() {
-  const { session } = useSupabase();
-  const router = useRouter();
-  const [open, setOpen] = useState(true);
-
-  useEffect(() => {
-    if (session) {
-      router.replace("/dashboard");
-    }
-  }, [session, router]);
-
-  return <AuthDialog open={open} onOpenChange={(o) => setOpen(o)} />;
+  return (
+    <form>
+      <label htmlFor="email">Email:</label>
+      <input id="email" name="email" type="email" required />
+      <label htmlFor="password">Password:</label>
+      <input id="password" name="password" type="password" required />
+      <button formAction={login}>Log in</button>
+      <button formAction={signup}>Sign up</button>
+    </form>
+  )
 }

--- a/src/app/private/page.tsx
+++ b/src/app/private/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/utils/supabase/server'
+
+export default async function PrivatePage() {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data?.user) {
+    redirect('/login')
+  }
+  return <p>Hello {data.user.email}</p>
+}

--- a/src/contexts/SupabaseProvider.tsx
+++ b/src/contexts/SupabaseProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
-import { createClient, SupabaseClient, Session } from "@supabase/supabase-js";
+import type { SupabaseClient, Session } from "@supabase/supabase-js";
+import { createClient } from "@/utils/supabase/client";
 
 interface SupabaseContextType {
   supabase: SupabaseClient;
@@ -11,14 +12,7 @@ interface SupabaseContextType {
 const SupabaseContext = createContext<SupabaseContextType | undefined>(undefined);
 
 export const SupabaseProvider = ({ children }: { children: React.ReactNode }) => {
-  const supabase = useMemo(
-    () =>
-      createClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-      ),
-    []
-  );
+  const supabase = useMemo(() => createClient(), []);
 
   const [session, setSession] = useState<Session | null>(null);
 

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,25 +1,6 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { cookies } from 'next/headers';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@/utils/supabase/server';
 
 export async function createServerSupabaseClient(): Promise<SupabaseClient> {
-  const cookieStore = cookies();
-  const access_token = cookieStore.get('sb-access-token')?.value;
-  const refresh_token = cookieStore.get('sb-refresh-token')?.value;
-
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      auth: {
-        persistSession: false,
-        autoRefreshToken: false,
-      },
-    }
-  );
-
-  if (access_token && refresh_token) {
-    await supabase.auth.setSession({ access_token, refresh_token });
-  }
-
-  return supabase;
+  return createClient();
 }

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+}

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -1,0 +1,31 @@
+import { createMiddlewareClient } from '@supabase/ssr'
+import { type NextRequest, NextResponse } from 'next/server'
+
+export async function updateSession(request: NextRequest) {
+  const response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  })
+
+  const supabase = createMiddlewareClient({
+    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    cookies: {
+      get(name: string) {
+        return request.cookies.get(name)?.value
+      },
+      set(name: string, value: string, options: any) {
+        request.cookies.set({ name, value, ...options })
+        response.cookies.set({ name, value, ...options })
+      },
+      remove(name: string, options: any) {
+        request.cookies.set({ name, value: '', ...options })
+        response.cookies.set({ name, value: '', ...options })
+      },
+    },
+  })
+
+  await supabase.auth.getUser()
+  return response
+}

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers'
+import { createServerClient } from '@supabase/ssr'
+
+export function createClient() {
+  const cookieStore = cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: any) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: any) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
+}


### PR DESCRIPTION
## 概要
- supabase/ssr を用いた認証機構に変更
- ミドルウェアでセッション更新処理を実装
- ログイン処理をサーバーアクション化
- 認証確認ルートやプライベートページを追加

## テスト
- `yarn lint` 実行 → lockfile 不足で失敗
- `yarn typecheck` 実行 → lockfile 不足で失敗
- `npm test` 実行 → スクリプト未定義のため失敗

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684e984827a8832b9d10936d8d08cc64