### PR TITLE
fix middleware client

### DIFF
--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -1,4 +1,4 @@
-import { createMiddlewareClient } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 import { type NextRequest, NextResponse } from 'next/server'
 
 export async function updateSession(request: NextRequest) {
@@ -8,23 +8,25 @@ export async function updateSession(request: NextRequest) {
     },
   })
 
-  const supabase = createMiddlewareClient({
-    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    cookies: {
-      get(name: string) {
-        return request.cookies.get(name)?.value
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return request.cookies.get(name)?.value
+        },
+        set(name: string, value: string, options: any) {
+          request.cookies.set({ name, value, ...options })
+          response.cookies.set({ name, value, ...options })
+        },
+        remove(name: string, options: any) {
+          request.cookies.set({ name, value: '', ...options })
+          response.cookies.set({ name, value: '', ...options })
+        },
       },
-      set(name: string, value: string, options: any) {
-        request.cookies.set({ name, value, ...options })
-        response.cookies.set({ name, value, ...options })
-      },
-      remove(name: string, options: any) {
-        request.cookies.set({ name, value: '', ...options })
-        response.cookies.set({ name, value: '', ...options })
-      },
-    },
-  })
+    }
+  )
 
   await supabase.auth.getUser()
   return response


### PR DESCRIPTION
## Summary
- middlewareのSupabaseクライアント生成を`createServerClient`に変更

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn typecheck` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684e9f66f368832b9aa17b516e613dd8