### PR TITLE
セッションクッキーの安全性改善

### DIFF
--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const { access_token, refresh_token } = await request.json()
+  const opts = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    sameSite: 'lax' as const,
+  }
+  if (access_token && refresh_token) {
+    cookies().set('sb-access-token', access_token, opts)
+    cookies().set('sb-refresh-token', refresh_token, opts)
+  } else {
+    cookies().set('sb-access-token', '', { ...opts, maxAge: 0 })
+    cookies().set('sb-refresh-token', '', { ...opts, maxAge: 0 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/src/contexts/SupabaseProvider.tsx
+++ b/src/contexts/SupabaseProvider.tsx
@@ -27,13 +27,16 @@ export const SupabaseProvider = ({ children }: { children: React.ReactNode }) =>
   }, [supabase]);
 
   useEffect(() => {
-    if (session) {
-      document.cookie = `sb-access-token=${session.access_token}; path=/; SameSite=Lax`;
-      document.cookie = `sb-refresh-token=${session.refresh_token}; path=/; SameSite=Lax`;
-    } else {
-      document.cookie = `sb-access-token=; path=/; max-age=0`;
-      document.cookie = `sb-refresh-token=; path=/; max-age=0`;
-    }
+    fetch("/api/session", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        access_token: session?.access_token ?? null,
+        refresh_token: session?.refresh_token ?? null,
+      }),
+    });
   }, [session]);
 
   return (


### PR DESCRIPTION
## 概要
SupabaseProvider でアクセストークンを `document.cookie` へ設定していたため、XSS 時に窃取される恐れがありました。これを解消するため、認証状態の変更をサーバー側で HTTP-only Cookie として保存する仕組みを追加しました。

## 主な変更点
- `/api/session` ルートハンドラを追加し、アクセストークンとリフレッシュトークンを HTTP-only/Secure/SameSite=Lax で保存
- SupabaseProvider での `document.cookie` 設定を廃止し、新ルートへトークンを送信

## テスト
- `npm run lint` と `npm run typecheck` を実行しましたが、依存パッケージが無いためコマンド失敗を確認


------
https://chatgpt.com/codex/tasks/task_e_684ea3a42594832b8cd7269aecdf8945