### PR TITLE
Add CSRF state check for OTP confirmation

### DIFF
--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -1,22 +1,26 @@
 import { type EmailOtpType } from '@supabase/supabase-js'
-import { type NextRequest } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
 import { createClient } from '@/utils/supabase/server'
-import { redirect } from 'next/navigation'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const token_hash = searchParams.get('token_hash')
   const type = searchParams.get('type') as EmailOtpType | null
   const next = searchParams.get('next') ?? '/'
-  if (token_hash && type) {
+  const state = searchParams.get('state')
+  const cookieStore = cookies()
+  const storedState = cookieStore.get('auth_state')?.value
+  if (token_hash && type && state && storedState === state) {
     const supabase = await createClient()
     const { error } = await supabase.auth.verifyOtp({
       type,
       token_hash,
     })
+    cookieStore.delete('auth_state')
     if (!error) {
-      redirect(next)
+      return NextResponse.redirect(new URL(next, request.url))
     }
   }
-  redirect('/error')
+  return NextResponse.redirect(new URL('/error', request.url))
 }

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
+import { headers, cookies } from 'next/headers'
 
 export async function login(formData: FormData) {
   const supabase = createClient()
@@ -18,7 +19,23 @@ export async function signup(formData: FormData) {
   const supabase = createClient()
   const email = formData.get('email') as string
   const password = formData.get('password') as string
-  const { error } = await supabase.auth.signUp({ email, password })
+  const state = crypto.randomUUID()
+  const origin =
+    headers().get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  cookies().set('auth_state', state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+    maxAge: 60 * 10,
+  })
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: `${origin}/auth/confirm?state=${state}`,
+    },
+  })
   if (error) {
     redirect('/error')
   }


### PR DESCRIPTION
## Summary
- OTP確認(/auth/confirm)でStateパラメータによるCSRF対策を追加
- サインアップ時にStateをCookieへ保存し確認リンクへ付与

## Testing
- `yarn typecheck` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684ea391389c832b9b9325d0bb8e8d4f