### PR TITLE
Fix toast duration

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,8 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// トーストが自動的に消えるまでの時間（ms）
+const TOAST_REMOVE_DELAY = 4000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## 変更内容
- `use-toast.ts` における自動消滅時間を 1000000ms から 4000ms に変更

## テスト結果
- `next lint` を実行しましたが、ネットワーク制限により依存関係の取得に失敗しました


------
https://chatgpt.com/codex/tasks/task_e_684ea3dcaee8832baf21cc6576a241de