### PR TITLE
Fix service role usage

### DIFF
--- a/src/hooks/useBetEntries.ts
+++ b/src/hooks/useBetEntries.ts
@@ -77,7 +77,7 @@ export function useBetEntries() {
 
   const addEntry = useCallback(async (newEntryData: Omit<BetEntry, 'id' | 'profitLoss' | 'roi'>) => {
     if (!session) return;
-    await insertBetEntry(session.user.id, {
+    await insertBetEntry({
       date: newEntryData.date,
       raceName: newEntryData.raceName,
       betAmount: newEntryData.betAmount,
@@ -91,7 +91,7 @@ export function useBetEntries() {
 
   const updateEntry = useCallback(async (id: string, updatedData: Omit<BetEntry, 'id' | 'profitLoss' | 'roi'>) => {
     if (!session) return;
-    await updateBetEntry(id, session.user.id, {
+    await updateBetEntry(id, {
       date: updatedData.date,
       raceName: updatedData.raceName,
       betAmount: updatedData.betAmount,
@@ -105,7 +105,7 @@ export function useBetEntries() {
 
   const deleteEntry = useCallback(async (id: string) => {
     if (!session) return;
-    await deleteBetEntry(id, session.user.id);
+    await deleteBetEntry(id);
     toast({
       title: '成功',
       description: 'エントリーが削除されました。',


### PR DESCRIPTION
## Summary
- サーバーアクション `betEntries.ts` でサービスロールキーを利用しないよう修正
- ユーザーIDをサーバー側で取得するように変更
- それに伴い `useBetEntries` から渡すパラメータを調整

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn typecheck` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684ea2dbcfbc832ba61ed7407e96a4c0