### PR TITLE
Add Spinner component to fix Loader2 key collision

### DIFF
--- a/src/app/dashboard/DashboardPageClient.tsx
+++ b/src/app/dashboard/DashboardPageClient.tsx
@@ -8,7 +8,8 @@ import { useBetEntries } from '@/hooks/useBetEntries';
 import { useEffect, useState, useMemo } from 'react';
 import type { BetEntry } from '@/lib/types';
 import { Button } from "@/components/ui/button";
-import { ArrowUp, ArrowDown, FilterX, CalendarDays, Save, Loader2 } from 'lucide-react'; // Loader2 を追加
+import { ArrowUp, ArrowDown, FilterX, CalendarDays, Save } from 'lucide-react';
+import { Spinner } from '@/components/ui/spinner';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from "@/components/ui/dialog";
 import useLocalStorage from '@/hooks/useLocalStorage';
 import type { ComponentType } from 'react';
@@ -115,7 +116,7 @@ function DashboardPageContent() {
   if (!isLoaded || !clientMounted) {
     return (
       <div className="flex flex-col items-center justify-center h-64 space-y-2" data-ai-hint="loading spinner">
-        <Loader2 className="h-8 w-8 animate-spin text-accent" />
+        <Spinner key="dashboard-spinner" className="h-8 w-8 text-accent" />
         <p className="text-lg text-muted-foreground">データを読み込み中...</p>
       </div>
     );

--- a/src/app/dashboard/entries/EntriesPageClient.tsx
+++ b/src/app/dashboard/entries/EntriesPageClient.tsx
@@ -4,7 +4,7 @@
 import { EntriesTable } from '@/components/EntriesTable';
 import { useBetEntries } from '@/hooks/useBetEntries';
 import { useEffect, useState } from 'react';
-import { Loader2 } from 'lucide-react'; // Loader2 を追加
+import { Spinner } from '@/components/ui/spinner';
 
 export default function EntriesPageClient() {
   const { entries, addEntry, updateEntry, deleteEntry, isLoaded } = useBetEntries();
@@ -17,7 +17,7 @@ export default function EntriesPageClient() {
   if (!isLoaded || !clientMounted) {
     return (
       <div className="flex flex-col items-center justify-center h-64 space-y-2" data-ai-hint="loading spinner">
-        <Loader2 className="h-8 w-8 animate-spin text-accent" />
+        <Spinner key="entries-spinner" className="h-8 w-8 text-accent" />
         <p className="text-lg text-muted-foreground">データを読み込み中...</p>
       </div>
     );

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+export interface SpinnerProps extends React.SVGAttributes<SVGSVGElement> {}
+
+export const Spinner = React.forwardRef<SVGSVGElement, SpinnerProps>(
+  ({ className, ...props }, ref) => (
+    <Loader2 ref={ref} className={cn("animate-spin", className)} {...props} />
+  )
+)
+Spinner.displayName = "Spinner"
+


### PR DESCRIPTION
## Summary
- Spinner コンポーネントを追加して `Loader2` の複数インスタンスによる DOM/ARIA エラーを防止
- Dashboard と Entries のローディング表示を Spinner に差し替え

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn typecheck` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684ea3d1fda8832bbb6424a59fd76da3