### PR TITLE
Optimize entries memoization

### DIFF
--- a/src/app/dashboard/DashboardPageClient.tsx
+++ b/src/app/dashboard/DashboardPageClient.tsx
@@ -89,6 +89,13 @@ function DashboardPageContent() {
     return tempEntries;
   }, [allEntries, startDate, endDate, isLoaded, clientMounted]);
 
+  // 並び替えたエントリーをメモ化して参照の安定化を図る
+  const sortedEntries = useMemo(() => {
+    return [...filteredEntries].sort((a, b) =>
+      parseISO(a.date).getTime() - parseISO(b.date).getTime()
+    );
+  }, [filteredEntries]);
+
   const moveCardInDialog = (index: number, direction: 'up' | 'down') => {
     const newOrder = [...tempCardOrder];
     if (direction === 'up' && index > 0) {
@@ -123,12 +130,12 @@ function DashboardPageContent() {
   }
 
   const componentsToRender = {
-    stats: { component: DashboardCards, props: { entries: filteredEntries } },
-    chart: { component: ProfitChart, props: { entries: filteredEntries } },
+    stats: { component: DashboardCards, props: { entries: sortedEntries } },
+    chart: { component: ProfitChart, props: { entries: sortedEntries } },
     table: {
       component: EntriesTable,
       props: {
-        entries: filteredEntries,
+        entries: sortedEntries,
         onDeleteEntry: deleteEntry,
         onUpdateEntry: updateEntry,
         displayLimit: 5,


### PR DESCRIPTION
## 概要
DashboardPageClient でフィルタ後のエントリーをソートした上で `useMemo` し、`DashboardCards` などへ安定した参照を渡すようにしました。これにより `calculateStats` が不要に再計算される回数を削減します。

## 変更点
- `sortedEntries` を追加し `filteredEntries` をソートしてメモ化
- 各カードコンポーネントへ `sortedEntries` を渡すよう更新

## テスト
- `yarn lint` 実行 *(依存パッケージ未取得のためエラー)*
- `yarn typecheck` 実行 *(依存パッケージ未取得のためエラー)*


------
https://chatgpt.com/codex/tasks/task_e_684eaadeddb4832bb7b55c49c4cddad6