### PR TITLE
Improve cumulative chart data performance

### DIFF
--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -1,6 +1,6 @@
 
 import type { BetEntry, DashboardStats, ChartDataPoint, ProfitChartTimespan } from './types';
-import { format, parseISO, getWeek, getYear, addDays } from 'date-fns';
+import { format, parseISO, getWeek, getYear, eachDayOfInterval } from 'date-fns';
 
 export function calculateStats(entries: BetEntry[]): DashboardStats {
   let totalInvestment = 0;
@@ -86,83 +86,43 @@ export function prepareCumulativeProfitChartData(entries: BetEntry[], timespan: 
   const sortedEntries = [...entries].sort((a, b) => parseISO(a.date).getTime() - parseISO(b.date).getTime());
 
   let cumulativeProfit = 0;
-  const dailyCumulativeProfitsWithEntries: Record<string, number> = {};
-
+  const profitMap = new Map<string, number>();
   for (const entry of sortedEntries) {
     cumulativeProfit += entry.profitLoss;
     const dateKey = format(parseISO(entry.date), 'yyyy-MM-dd');
-    dailyCumulativeProfitsWithEntries[dateKey] = cumulativeProfit;
+    profitMap.set(dateKey, cumulativeProfit);
   }
 
-  if (Object.keys(dailyCumulativeProfitsWithEntries).length === 0) {
-    return []; 
-  }
-  
-  const firstDateStr = Object.keys(dailyCumulativeProfitsWithEntries).sort()[0];
-  const lastDateStr = sortedEntries.length > 0 ? format(parseISO(sortedEntries[sortedEntries.length -1].date), 'yyyy-MM-dd') : firstDateStr;
-  
-  let currentDate = parseISO(firstDateStr);
-  const lastDate = parseISO(lastDateStr);
-  let lastKnownProfit = 0;
-  
-  // 最初のエントリー以前の累積利益を算出
-  // これにより、過去にエントリーがあった場合もグラフの起点がずれない
-  let initialBaselineProfit = 0;
-    for (const entry of sortedEntries) {
-        if (parseISO(entry.date) < parseISO(firstDateStr)) {
-            initialBaselineProfit += entry.profitLoss;
-        } else {
-            break; 
-        }
-    }
-  lastKnownProfit = initialBaselineProfit;
+  const firstDate = parseISO(sortedEntries[0].date);
+  const lastDate = parseISO(sortedEntries[sortedEntries.length - 1].date);
 
-  
-  const allDailyProfits: Record<string, number> = {};
-  while (currentDate <= lastDate) {
-    const dateKey = format(currentDate, 'yyyy-MM-dd');
-    if (dailyCumulativeProfitsWithEntries[dateKey] !== undefined) {
-      lastKnownProfit = dailyCumulativeProfitsWithEntries[dateKey];
-    } else if (currentDate >= parseISO(firstDateStr)) { // 初回以降の日は前日の利益を引き継ぐ
-        // エントリーのない日は直前の利益を流用
-        allDailyProfits[dateKey] = lastKnownProfit;
-    } else {
-        // エントリー前の日は初期基準値を使用
-        allDailyProfits[dateKey] = initialBaselineProfit;
-    }
-     if (dailyCumulativeProfitsWithEntries[dateKey] !== undefined) {
-      allDailyProfits[dateKey] = dailyCumulativeProfitsWithEntries[dateKey]; // 実際のエントリー日の値を優先
-    } else {
-      allDailyProfits[dateKey] = lastKnownProfit; // エントリーがない日は直前値を使用
-    }
-    currentDate = addDays(currentDate, 1);
-  }
-  
   const aggregatedData: Record<string, number> = {};
-  Object.entries(allDailyProfits).forEach(([dateStr, profit]) => {
-      const date = parseISO(dateStr);
-      let key: string;
-      switch (timespan) {
-          case 'daily':
-              key = dateStr;
-              aggregatedData[key] = profit;
-              break;
-          case 'weekly':
-              key = `${getYear(date)}-W${String(getWeek(date, { weekStartsOn: 1 })).padStart(2, '0')}`;
-              // 週次・月次の場合はその期間の終了時点の累積利益を使用する
-              // そのためここでは最新の値を採用している
-              aggregatedData[key] = profit; 
-              break;
-          case 'monthly':
-              key = format(date, 'yyyy-MM');
-              aggregatedData[key] = profit;
-              break;
-      }
-  });
+  let lastKnownProfit = 0;
+
+  for (const date of eachDayOfInterval({ start: firstDate, end: lastDate })) {
+    const dateKey = format(date, 'yyyy-MM-dd');
+    if (profitMap.has(dateKey)) {
+      lastKnownProfit = profitMap.get(dateKey)!;
+    }
+
+    let key: string;
+    switch (timespan) {
+      case 'daily':
+        key = dateKey;
+        break;
+      case 'weekly':
+        key = `${getYear(date)}-W${String(getWeek(date, { weekStartsOn: 1 })).padStart(2, '0')}`;
+        break;
+      case 'monthly':
+        key = format(date, 'yyyy-MM');
+        break;
+    }
+    aggregatedData[key] = lastKnownProfit;
+  }
 
   return Object.entries(aggregatedData)
-      .map(([name, value]) => ({ name, value }))
-      .sort((a,b) => a.name.localeCompare(b.name));
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 


### PR DESCRIPTION
## Summary
- 累積損益グラフの計算を1パス化

## Testing
- `yarn lint` *(失敗: lockfile がないため)*
- `yarn typecheck` *(失敗: lockfile がないため)*

------
https://chatgpt.com/codex/tasks/task_e_684eaaeca0bc832ba4dc576dd95d66a8