### PR TITLE
Allow nullable payout and show placeholder

### DIFF
--- a/docs/supabase_schema.md
+++ b/docs/supabase_schema.md
@@ -26,7 +26,7 @@
 | date        | `date`                     | NOT NULL                                | レース日        |
 | race_name   | `text`                     | NOT NULL, DEFAULT ''                    | レース名        |
 | stake       | `numeric`                  | NOT NULL                                | 賭け金          |
-| payout      | `numeric`                  | NOT NULL, DEFAULT 0                     | 払戻金          |
+| payout      | `numeric`                  | DEFAULT NULL                            | 払戻金 (未確定は NULL) |
 | inserted_at | `timestamp with time zone` | DEFAULT now()                           | 作成日時        |
 | updated_at  | `timestamp with time zone` | DEFAULT now(), トリガーで自動更新       | 更新日時        |
 

--- a/src/app/actions/betEntries.ts
+++ b/src/app/actions/betEntries.ts
@@ -6,7 +6,7 @@ type EntryBase = {
   date: string;
   raceName?: string;
   betAmount: number;
-  payoutAmount: number;
+  payoutAmount: number | null;
 };
 
 function getClient() {

--- a/src/components/EntriesTable.tsx
+++ b/src/components/EntriesTable.tsx
@@ -139,11 +139,11 @@ export function EntriesTable({
         let bValue = b[sortConfig.key as keyof BetEntry];
 
         if (sortConfig.key === 'profitLoss') {
-            aValue = a.payoutAmount - a.betAmount;
-            bValue = b.payoutAmount - b.betAmount;
+            aValue = (a.payoutAmount ?? 0) - a.betAmount;
+            bValue = (b.payoutAmount ?? 0) - b.betAmount;
         } else if (sortConfig.key === 'roi') {
-            aValue = a.betAmount > 0 ? (a.payoutAmount / a.betAmount) * 100 : 0;
-            bValue = b.betAmount > 0 ? (b.payoutAmount / b.betAmount) * 100 : 0;
+            aValue = a.betAmount > 0 ? ((a.payoutAmount ?? 0) / a.betAmount) * 100 : 0;
+            bValue = b.betAmount > 0 ? ((b.payoutAmount ?? 0) / b.betAmount) * 100 : 0;
         }
 
 
@@ -188,7 +188,7 @@ export function EntriesTable({
     }
 
     const currentTotalBetAmount = sourceForTotals.reduce((sum, entry) => sum + entry.betAmount, 0);
-    const currentTotalPayoutAmount = sourceForTotals.reduce((sum, entry) => sum + entry.payoutAmount, 0);
+    const currentTotalPayoutAmount = sourceForTotals.reduce((sum, entry) => sum + (entry.payoutAmount ?? 0), 0);
     const currentTotalProfitLoss = currentTotalPayoutAmount - currentTotalBetAmount;
     const currentOverallRecoveryRate = currentTotalBetAmount > 0 ? (currentTotalPayoutAmount / currentTotalBetAmount) * 100 : 0;
 
@@ -427,11 +427,11 @@ export function EntriesTable({
                         <TableCell>{isValid(parseISO(entry.date)) ? format(parseISO(entry.date), "yyyy/MM/dd") : '-'}</TableCell>
                         <TableCell className="whitespace-nowrap">{entry.raceName || "-"}</TableCell>
                         <TableCell className="text-right whitespace-nowrap">{formatCurrency(entry.betAmount)}</TableCell>
-                        <TableCell className="text-right whitespace-nowrap">{formatCurrency(entry.payoutAmount)}</TableCell>
+                        <TableCell className="text-right whitespace-nowrap">{entry.payoutAmount === null ? '–' : formatCurrency(entry.payoutAmount)}</TableCell>
                         <TableCell className={`text-right font-medium whitespace-nowrap ${entry.profitLoss >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                          {formatCurrency(entry.profitLoss)}
+                          {entry.payoutAmount === null ? '–' : formatCurrency(entry.profitLoss)}
                         </TableCell>
-                        <TableCell className="text-right whitespace-nowrap">{formatPercentage(entry.roi)}</TableCell>
+                        <TableCell className="text-right whitespace-nowrap">{entry.payoutAmount === null ? '–' : formatPercentage(entry.roi)}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -29,7 +29,10 @@ const formSchema = z.object({
   }),
   raceName: z.string().optional(),
   betAmount: z.coerce.number().min(1, { message: "1円以上の掛け金を入力してください。" }).step(100),
-  payoutAmount: z.coerce.number().min(0, { message: "0円以上の払戻金を入力してください。" }).step(10),
+  payoutAmount: z.preprocess(
+    (v) => v === '' || v === undefined || v === null ? null : Number(v),
+    z.number().min(0, { message: "0円以上の払戻金を入力してください。" }).step(10).nullable()
+  ),
 });
 
 type EntryFormValues = z.infer<typeof formSchema>;
@@ -59,7 +62,7 @@ export function EntryForm({
       date: initialData ? parseISO(initialData.date) : new Date(),
       raceName: initialData?.raceName || "",
       betAmount: initialData?.betAmount || 100,
-      payoutAmount: initialData?.payoutAmount || 0,
+      payoutAmount: initialData?.payoutAmount ?? null,
     },
   });
 
@@ -76,7 +79,7 @@ export function EntryForm({
         date: new Date(),
         raceName: "",
         betAmount: 100,
-        payoutAmount: 0,
+        payoutAmount: null,
       });
     }
   }, [initialData, form, isEditMode]);
@@ -95,7 +98,7 @@ export function EntryForm({
           date: new Date(),
           raceName: "",
           betAmount: 100,
-          payoutAmount: 0,
+          payoutAmount: null,
         });
       }
     }
@@ -197,7 +200,7 @@ export function EntryForm({
                   <FormItem>
                     <FormLabel>払戻金 (円)</FormLabel>
                     <FormControl>
-                      <Input type="number" placeholder="1500" step="10" {...field} />
+                      <Input type="number" placeholder="1500" step="10" value={field.value ?? ''} onChange={field.onChange} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -212,7 +215,7 @@ export function EntryForm({
                       date: new Date(),
                       raceName: "",
                       betAmount: 100,
-                      payoutAmount: 0,
+                      payoutAmount: null,
                     });
                   }}>
                     リセット

--- a/src/hooks/useBetEntries.ts
+++ b/src/hooks/useBetEntries.ts
@@ -8,9 +8,10 @@ import { toast } from './use-toast'; // トースト表示用のフックを追�
 import { useSupabase } from '@/contexts/SupabaseProvider';
 import { insertBetEntry, updateBetEntry, deleteBetEntry } from '@/app/actions/betEntries';
 
-const calculateEntryFields = (betAmount: number, payoutAmount: number): Pick<BetEntry, 'profitLoss' | 'roi'> => {
-  const profitLoss = payoutAmount - betAmount;
-  const roi = betAmount > 0 ? (payoutAmount / betAmount) * 100 : 0; // 個別の回収率
+const calculateEntryFields = (betAmount: number, payoutAmount: number | null): Pick<BetEntry, 'profitLoss' | 'roi'> => {
+  const payout = payoutAmount ?? 0;
+  const profitLoss = payout - betAmount;
+  const roi = betAmount > 0 ? (payout / betAmount) * 100 : 0; // 個別の回収率
   return { profitLoss, roi };
 };
 
@@ -21,13 +22,13 @@ export function useBetEntries() {
   const channelRef = useRef<RealtimeChannel | null>(null);
 
   const mapRow = (row: any): BetEntry => {
-    const { profitLoss, roi } = calculateEntryFields(row.stake, row.payout ?? 0);
+    const { profitLoss, roi } = calculateEntryFields(row.stake, row.payout);
     return {
       id: row.id,
       date: row.date,
       raceName: row.race_name,
       betAmount: row.stake,
-      payoutAmount: row.payout ?? 0,
+      payoutAmount: row.payout,
       profitLoss,
       roi,
     };

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -9,13 +9,14 @@ export function calculateStats(entries: BetEntry[]): DashboardStats {
   let maxPayoutPerRace = 0;
 
   entries.forEach(entry => {
+    const payout = entry.payoutAmount ?? 0;
     totalInvestment += entry.betAmount;
-    totalPayout += entry.payoutAmount;
-    if (entry.payoutAmount > entry.betAmount) { // 払戻金が掛け金を上回れば的中
+    totalPayout += payout;
+    if (payout > entry.betAmount) { // 払戻金が掛け金を上回れば的中
       winningEntryCount++;
     }
-    if (entry.payoutAmount > maxPayoutPerRace) {
-      maxPayoutPerRace = entry.payoutAmount;
+    if (payout > maxPayoutPerRace) {
+      maxPayoutPerRace = payout;
     }
   });
 
@@ -169,7 +170,7 @@ export function prepareCumulativeProfitChartData(entries: BetEntry[], timespan: 
 export function calculateAverageRecoveryRate(entries: BetEntry[]): number {
   if (entries.length === 0) return 0;
   const totalInvestment = entries.reduce((sum, entry) => sum + entry.betAmount, 0);
-  const totalPayout = entries.reduce((sum, entry) => sum + entry.payoutAmount, 0);
+  const totalPayout = entries.reduce((sum, entry) => sum + (entry.payoutAmount ?? 0), 0);
   if (totalInvestment === 0) return 0;
   // 回収率 = (総払戻額 / 総投資額) * 100
   return (totalPayout / totalInvestment) * 100;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,7 +3,7 @@ export interface BetEntry {
   date: string; // ISO 形式 "YYYY-MM-DD"
   raceName?: string;
   betAmount: number;
-  payoutAmount: number;
+  payoutAmount: number | null;
   profitLoss: number; // 払戻金 - 掛け金 で計算
   roi: number; // (payoutAmount / betAmount) * 100 で計算した回収率。betAmount が 0 の場合も考慮
 }


### PR DESCRIPTION
## Summary
- payout カラムを NULL 可能にしドキュメント更新
- payoutAmount 型を `number | null` に変更
- 未確定の払戻金はテーブルで "–" 表示
- フォームで払戻金を未入力可能にし、空欄は null として送信
- 計算処理や集計処理を null 対応

## Testing
- `yarn lint` *(failed: package missing in lockfile)*
- `yarn typecheck` *(failed: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684eab0182b8832b9094e218334d8a17