### PR TITLE
Fix server client cookie handling

### DIFF
--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -8,14 +8,14 @@ export function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        async get(name: string) {
-          return (await cookieStore).get(name)?.value
+        get(name: string) {
+          return cookieStore.get(name)?.value
         },
-        async set(name: string, value: string, options: any) {
-          (await cookieStore).set({ name, value, ...options })
+        set(name: string, value: string, options: any) {
+          cookieStore.set({ name, value, ...options })
         },
-        async remove(name: string, options: any) {
-          (await cookieStore).delete({ name, ...options })
+        remove(name: string, options: any) {
+          cookieStore.delete({ name, ...options })
         },
       },
     }


### PR DESCRIPTION
## Summary
- サーバー側SupabaseクライアントでCookie取得処理のasync/awaitを削除

## Testing
- `npm run lint` *(失敗: `next` コマンドが見つからず)*
- `npm run typecheck` *(依存モジュールが無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_684ebe8975a4832b85258ea4b3ca262b