### PR TITLE
Fix realtime channel cleanup

### DIFF
--- a/src/hooks/useBetEntries.ts
+++ b/src/hooks/useBetEntries.ts
@@ -39,7 +39,7 @@ export function useBetEntries() {
       setEntries([]);
       setIsLoaded(true);
       if (channelRef.current) {
-        supabase.removeChannel(channelRef.current);
+        channelRef.current.unsubscribe();
         channelRef.current = null;
       }
       return;
@@ -57,10 +57,10 @@ export function useBetEntries() {
       setIsLoaded(true);
 
       if (channelRef.current) {
-        supabase.removeChannel(channelRef.current);
+        channelRef.current.unsubscribe();
       }
       channelRef.current = supabase
-        .channel('public:bet_entries')
+        .channel(`public:bet_entries:${session.user.id}`)
         .on(
           'postgres_changes',
           { event: '*', schema: 'public', table: 'bet_entries', filter: `user_id=eq.${session.user.id}` },
@@ -81,7 +81,7 @@ export function useBetEntries() {
 
     return () => {
       if (channelRef.current) {
-        supabase.removeChannel(channelRef.current);
+        channelRef.current.unsubscribe();
         channelRef.current = null;
       }
     };


### PR DESCRIPTION
## Summary
- realtimeチャンネルの破棄を `unsubscribe()` に変更
- チャンネル名をユーザーごとに変更

## Testing
- `npm run lint` *(failed: next not found)*
- `npm run typecheck` *(failed: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ebeac4090832bb31ca3b7e1af57fa