### PR TITLE
Fix cookie delete method

### DIFF
--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -21,8 +21,8 @@ export async function updateSession(request: NextRequest) {
           response.cookies.set({ name, value, ...options })
         },
         remove(name: string, options: any) {
-          request.cookies.set({ name, value: '', ...options })
-          response.cookies.set({ name, value: '', ...options })
+          request.cookies.delete(name, options)
+          response.cookies.delete(name, options)
         },
       },
     }


### PR DESCRIPTION
## 概要
- Supabase ミドルウェアの cookie 削除処理で未定義の `value` を参照しないよう修正しました。

## テスト
- `yarn lint` を実行しましたが依存パッケージが無いため失敗しました。

------
https://chatgpt.com/codex/tasks/task_e_684ebe9cf6a0832b8af758fa0170c7e9