### PR TITLE
Return ID on insert

### DIFF
--- a/src/app/actions/betEntries.ts
+++ b/src/app/actions/betEntries.ts
@@ -23,12 +23,17 @@ function mapToDb(userId: string, data: EntryBase) {
   };
 }
 
-export async function insertBetEntry(data: EntryBase) {
+export async function insertBetEntry(data: EntryBase): Promise<string> {
   const supabase = getClient();
   const { data: { user }, error: authError } = await supabase.auth.getUser();
   if (authError || !user) throw authError ?? new Error('Unauthorized');
-  const { error } = await supabase.from('bet_entries').insert(mapToDb(user.id, data));
+  const { data: inserted, error } = await supabase
+    .from('bet_entries')
+    .insert(mapToDb(user.id, data))
+    .select('id')
+    .single();
   if (error) throw error;
+  return inserted.id;
 }
 
 export async function updateBetEntry(id: string, data: EntryBase) {

--- a/src/hooks/useBetEntries.ts
+++ b/src/hooks/useBetEntries.ts
@@ -90,7 +90,7 @@ export function useBetEntries() {
   const addEntry = useCallback(async (newEntryData: Omit<BetEntry, 'id' | 'profitLoss' | 'roi'>) => {
     if (!session) return;
     try {
-      await insertBetEntry({
+      const id = await insertBetEntry({
         date: newEntryData.date,
         raceName: newEntryData.raceName,
         betAmount: newEntryData.betAmount,
@@ -100,6 +100,7 @@ export function useBetEntries() {
         title: '成功',
         description: 'エントリーが追加されました。',
       });
+      return id;
     } catch (error) {
       console.error(error);
       toast({


### PR DESCRIPTION
## Summary
- サーバーアクション `insertBetEntry` が挿入直後の ID を返すように変更
- `useBetEntries` の `addEntry` でもその ID を返す

## Testing
- `yarn lint` *(failed: package not installed)*
- `yarn typecheck` *(failed: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ebec206d8832b9e8615efc859ffe7