### PR TITLE
Add Sentry reporting for failure toasts

### DIFF
--- a/src/hooks/useBetEntries.ts
+++ b/src/hooks/useBetEntries.ts
@@ -5,6 +5,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import type { BetEntry } from '@/lib/types';
 import { toast } from './use-toast'; // トースト表示用のフックを追加
+import { reportErrorToSentry } from '@/utils/sentry';
 import { useSupabase } from '@/contexts/SupabaseProvider';
 import { insertBetEntry, updateBetEntry, deleteBetEntry } from '@/app/actions/betEntries';
 
@@ -102,6 +103,7 @@ export function useBetEntries() {
       });
     } catch (error) {
       console.error(error);
+      reportErrorToSentry(error);
       toast({
         title: 'エラー',
         description: 'エントリーの追加に失敗しました。',
@@ -125,6 +127,7 @@ export function useBetEntries() {
       });
     } catch (error) {
       console.error(error);
+      reportErrorToSentry(error);
       toast({
         title: 'エラー',
         description: 'エントリーの更新に失敗しました。',
@@ -144,6 +147,7 @@ export function useBetEntries() {
       });
     } catch (error) {
       console.error(error);
+      reportErrorToSentry(error);
       toast({
         title: 'エラー',
         description: 'エントリーの削除に失敗しました。',

--- a/src/types/sentry.d.ts
+++ b/src/types/sentry.d.ts
@@ -1,0 +1,6 @@
+declare interface Window {
+  Sentry?: {
+    captureException?: (error: unknown) => void
+  }
+}
+

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -1,0 +1,13 @@
+export function reportErrorToSentry(error: unknown) {
+  try {
+    const sentry = (window as any).Sentry
+    if (sentry && typeof sentry.captureException === 'function') {
+      sentry.captureException(error)
+    } else {
+      console.error('Sentry is not initialized', error)
+    }
+  } catch (err) {
+    console.error('Failed to report to Sentry', err)
+  }
+}
+


### PR DESCRIPTION
## Summary
- トーストのエラー時に Sentry へ例外を送信する処理を追加
- Sentry 用ヘルパーと型定義を新規作成

## Testing
- `npm run typecheck` *(失敗)*
- `npm run lint` *(失敗)*

------
https://chatgpt.com/codex/tasks/task_e_684ebecbc07c832ba140a9bcb41b4b26