### PR TITLE
fix login redirect after signup

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,16 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { createClient } from "@/utils/supabase/client";
+import { useRouter } from "next/navigation";
+import { useSupabase } from "@/contexts/SupabaseProvider";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const { session } = useSupabase();
   const [supabase] = useState(() => createClient());
   const redirectTo =
     typeof window !== "undefined"
       ? `${window.location.origin}/dashboard`
       : undefined;
+
+  useEffect(() => {
+    if (session) {
+      router.replace("/dashboard");
+    }
+  }, [session, router]);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">


### PR DESCRIPTION
## 概要
サインアップ後に画面が遷移しない問題を修正しました。ログインページでセッションを監視し、ログイン済みの場合は自動でダッシュボードへ遷移します。

## 変更点
- `src/app/login/page.tsx` に `useRouter` と `useSupabase` を利用したリダイレクト処理を追加

## テスト
- `npm run lint` (失敗: `next` コマンドが見つからず)
- `npx next lint` (失敗: パッケージ取得が禁止されているため)
- `yarn lint` (失敗: lockfile 不足)
- `npm run typecheck` (失敗: モジュール解決エラー)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684ed079e394832ba89e685a4d67753f