### PR TITLE
fix realtime subscribe error

### DIFF
--- a/src/hooks/useBetEntries.ts
+++ b/src/hooks/useBetEntries.ts
@@ -59,6 +59,7 @@ export function useBetEntries() {
 
       if (channelRef.current) {
         channelRef.current.unsubscribe();
+        supabase.removeChannel(channelRef.current);
       }
       channelRef.current = supabase
         .channel(`public:bet_entries:${session.user.id}`)
@@ -83,6 +84,7 @@ export function useBetEntries() {
     return () => {
       if (channelRef.current) {
         channelRef.current.unsubscribe();
+        supabase.removeChannel(channelRef.current);
         channelRef.current = null;
       }
     };


### PR DESCRIPTION
## 概要
Realtime チャンネルを再購読する際に、以前のインスタンスが残っていると `subscribe` を複数回呼び出すことになりエラーが発生していました。
`unsubscribe` 後に `removeChannel` を呼び出すよう修正しました。

## テスト
- `npm install`（失敗）
- `npm run lint`（実行できず）


------
https://chatgpt.com/codex/tasks/task_e_684ed2c9299c832bb0b35f1c0519af5c